### PR TITLE
feat(Shop): ショップ作成機能に画像アップロードとユーザー情報を追加

### DIFF
--- a/src/src/app/Http/Controllers/ShopController.php
+++ b/src/src/app/Http/Controllers/ShopController.php
@@ -5,7 +5,11 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Shop;
 use App\Models\Review;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class ShopController extends Controller
 {
@@ -37,26 +41,65 @@ class ShopController extends Controller
         return Inertia::render('Shop/Create');
     }
 
-    public function store (Request $request) {
+    public function store(Request $request)
+    {
+        if (!Auth::check()) {
+            return redirect()->route('login');
+        }
+
+        $user = Auth::user();
 
         $request->validate([
             'name' => 'required|string|max:255',
-            'location' => 'required|string|max:255',
+            'location' => 'required|string|max:255', 
             'description' => 'required|string',
         ]);
 
-        $shopModel = new Shop();
+        DB::beginTransaction();
+        try {
+            $shop = Shop::create([
+                'name' => $request->name,
+                'location' => $request->location,
+                'description' => $request->description,
+                'created_by' => $user->id,
+                'updated_by' => $user->id,
+            ]);
 
-        $shop = $shopModel->saveShop([
-            'name' => $request->name,
-            'location' => $request->location,
-            'description' => $request->description,
-        ]);
+            if ($request->hasFile('images')) {
+                $images = $request->file('images');
+                foreach ($images as $image) {
+                    // Get image extension
+                    $extension = $image->getClientOriginalExtension();
+                    // Generate random string
+                    $random = Str::random(16);
+                    // Generate filename
+                    $fileName = $shop->id . '_' . $random . '.' . $extension;
+                    
+                    // Save image metadata
+                    $shop->images()->create([
+                        'shop_id' => $shop->id,
+                        'file_name' => $fileName,
+                        'file_path' => 'storage/shop_image/' . $fileName,
+                        'file_type' => $image->getClientMimeType(),
+                        'file_size' => $image->getSize(),
+                        'file_extension' => $extension,
+                        'file_mime' => $image->getClientMimeType(),
+                        'file_original_name' => $image->getClientOriginalName(),
+                        'file_original_extension' => $image->getClientOriginalExtension(),
+                    ]);
+                    
+                    // Store physical file
+                    $image->storeAs('public/shop_image', $fileName);
+                }
+            }
 
-        if($shop) {
-            $status = 'shop-created';
+            DB::commit();
+            return redirect()->route('home', ['status' => 'shop-created']);
+
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+            DB::rollBack();
+            throw $e;
         }
-
-        return redirect()->route('home',['status' => $status]);
     }
 }

--- a/src/src/app/Models/Shop.php
+++ b/src/src/app/Models/Shop.php
@@ -15,10 +15,30 @@ class Shop extends Model
         'name',
         'location',
         'description',
+        'created_by',
+        'updated_by',
     ];
 
     public function reviews()
     {
         return $this->hasMany(Review::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function saveShop($data)
+    {
+        $this->name = $data->name;
+        $this->location = $data->location;
+        $this->description = $data->description;
+        $this->create_by = $data->created_by;
+        $this->updated_by = $data->updated_by;
+
+        $this->save();
+
+        return $this;
     }
 }

--- a/src/src/app/Models/ShopImage.php
+++ b/src/src/app/Models/ShopImage.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class ShopImage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'shop_id',
+        'file_name',
+        'file_path',
+        'file_type',
+        'file_size',
+        'file_extension',
+        'file_mime',
+        'file_original_name',
+        'file_original_path',
+        'thumbnail_id',
+    ];
+
+    public function shop() 
+    {
+        return $this->belongsTo(Shop::class);
+    }
+
+    public function saveImage($data)
+    {
+        $this->shop_id = $data['shop_id'];
+        $this->file_name = $data['file_name'];
+        $this->file_path = $data['file_path'];
+        $this->file_type = $data['file_type'];
+        $this->file_size = $data['file_size'];
+        $this->file_extension = $data['file_extension'];
+        $this->file_mime = $data['file_mime'];
+        $this->file_original_name = $data['file_original_name'];
+        $this->file_original_path = $data['file_original_path'];
+
+        $this->save();
+    }
+}


### PR DESCRIPTION
ショップ作成時に画像をアップロードできる機能を追加し、ユーザー情報（created_by, updated_by）を保存するようにしました。また、ShopImageモデルを新規作成し、ショップと画像の関連を管理できるようにしました。トランザクションを使用してデータの整合性を保証し、エラーが発生した場合はログに記録してロールバックします。